### PR TITLE
Add the possibility to change the AirPlay text via the ManagedAppConfig

### DIFF
--- a/ImageView/Base.lproj/Main.storyboard
+++ b/ImageView/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder.AppleTV.Storyboard" version="3.0" toolsVersion="14313.18" targetRuntime="AppleTV" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder.AppleTV.Storyboard" version="3.0" toolsVersion="14490.70" targetRuntime="AppleTV" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="appleTV" orientation="landscape">
         <adaptation id="light"/>
     </device>
     <dependencies>
         <deployment identifier="tvOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -13,7 +13,7 @@
         <!--Main-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController title="Main" id="BYZ-38-t0r" customClass="ViewController" customModule="ImageView" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController title="Main" id="BYZ-38-t0r" customClass="ViewController" customModule="MDM_image_Viewer" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
@@ -55,7 +55,7 @@
                                         <nil key="highlightedColor"/>
                                         <size key="shadowOffset" width="6" height="5"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BS9-pu-iOB">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="4" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BS9-pu-iOB">
                                         <rect key="frame" x="44" y="93" width="376" height="113"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <edgeInsets key="layoutMargins" top="8" left="8" bottom="8" right="8"/>
@@ -72,14 +72,14 @@
                                         <size key="shadowOffset" width="6" height="5"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" usesAttributedText="YES" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hw5-Sk-E1F">
-                                        <rect key="frame" x="44" y="223" width="229" height="22"/>
+                                        <rect key="frame" x="44" y="223" width="376" height="22"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <attributedString key="attributedText">
                                             <fragment content="CHOOSE THIS APPLE TV">
                                                 <attributes>
                                                     <color key="NSColor" red="0.75296914577484131" green="0.75678956508636475" blue="0.76078504323959351" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                     <font key="NSFont" size="19" name="Helvetica-Bold"/>
-                                                    <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                    <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                                 </attributes>
                                             </fragment>
                                         </attributedString>
@@ -114,6 +114,8 @@
                         <viewLayoutGuide key="safeArea" id="wu6-TO-1qx"/>
                     </view>
                     <connections>
+                        <outlet property="airplayDescription" destination="BS9-pu-iOB" id="vd6-Yr-XyQ"/>
+                        <outlet property="airplaySubtitle" destination="Hw5-Sk-E1F" id="kir-7s-Vus"/>
                         <outlet property="airplayView" destination="eU8-1q-URt" id="gQY-wW-907"/>
                         <outlet property="deviceNameLabel" destination="TQY-LZ-Nuk" id="NSu-PN-hHb"/>
                         <outlet property="imageView" destination="36d-PX-doG" id="yYN-Ho-Ukz"/>
@@ -188,7 +190,7 @@
         </scene>
     </scenes>
     <resources>
-        <image name="AirPlay" width="36" height="36"/>
-        <image name="Nebraska" width="2560" height="1440"/>
+        <image name="AirPlay" width="75" height="75"/>
+        <image name="Nebraska" width="1280" height="720"/>
     </resources>
 </document>

--- a/ImageView/ViewController.swift
+++ b/ImageView/ViewController.swift
@@ -55,6 +55,8 @@ var imageTimer: Double = 10
 var airplayViewTimer: Double = 33
 var dataCheckTimer: Double = 180
 var defaultBackground: String = "DefaultBackground"
+var defaultDescription: String = "Wirelessly send what's on your iOS device or computer to this display using AirPlay. Learn more at help.apple.com/appletv."
+var defaultSubtitle: String = "CHOOSE THIS APPLE TV"
 
 // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 // End: Initialize and set defaults
@@ -70,6 +72,8 @@ class ViewController: UIViewController {
     @IBOutlet weak var topView: UIView!
     @IBOutlet weak var imageView: UIImageView!
     @IBOutlet weak var deviceNameLabel: UILabel!
+    @IBOutlet weak var airplaySubtitle: UILabel!
+    @IBOutlet weak var airplayDescription: UILabel!
     @IBOutlet weak var airplayView: UIView!
     
 
@@ -106,6 +110,8 @@ class ViewController: UIViewController {
         airplayViewTimer = 33
         dataCheckTimer = 180
         defaultBackground = "DefaultBackground"
+        defaultSubtitle = "Wirelessly send what's on your iOS device or computer to this display using AirPlay. Learn more at help.apple.com/appletv."
+        defaultDescription = "CHOOSE THIS APPLE TV"
         
         // Get Managed App Configuration passsed by MDM
         if keyPresentInUserDefaults(key: "edu.nebraska.ImageViewer.dataURL") {
@@ -127,6 +133,15 @@ class ViewController: UIViewController {
         if keyPresentInUserDefaults(key: "edu.nebraska.ImageViewer.defaultBackground") {
             defaultBackground = ManagedAppConfig.shared.getConfigValue(forKey: "edu.nebraska.ImageViewer.defaultBackground") as! String
         }
+        
+        if keyPresentInUserDefaults(key: "edu.nebraska.ImageViewer.defaultSubtitle") {
+            defaultSubtitle = ManagedAppConfig.shared.getConfigValue(forKey: "edu.nebraska.ImageViewer.defaultSubtitle") as! String
+        }
+        
+        if keyPresentInUserDefaults(key: "edu.nebraska.ImageViewer.defaultDescription") {
+            defaultDescription = ManagedAppConfig.shared.getConfigValue(forKey: "edu.nebraska.ImageViewer.defaultDescription") as! String
+        }
+        
         
         print(dataURL)
         print(imageTimer)
@@ -187,6 +202,9 @@ class ViewController: UIViewController {
     func loadGUIConfig() {
         
         deviceNameLabel.text = UIDevice.current.name
+        
+        airplaySubtitle.text = defaultSubtitle
+        airplayDescription.text = defaultDescription
         
         let blurEffect = UIBlurEffect(style: .dark)
         let blurredEffectView = UIVisualEffectView(effect: blurEffect)

--- a/ImageView/ViewController.swift
+++ b/ImageView/ViewController.swift
@@ -83,6 +83,7 @@ class ViewController: UIViewController {
 
         dateFormatter.dateFormat = "M/d/yy H:mm"
         loadInputRecognizer()
+        getManagedAppConfiguration()
         loadGUIConfig()
         loadImageSelection()
         loadRepeatingFunctions()

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ This value can be set to "DefaultBackgroundNoLogo" in order to remove the MDM Im
 	<integer>25</integer>
 	<key>edu.nebraska.ImageViewer.dataCheckTimer</key>
 	<integer>600</integer>
+  <key>edu.nebraska.ImageViewer.defaultSubtitle</key>
+	<string>SELECT THIS APPLE TV</string>
+	<key>edu.nebraska.ImageViewer.defaultDescription</key>
+	<string>New AirPlay description</string>
 </dict>
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Time (in seconds) between movements of the AirPlay box. The default time is set 
 **edu.nebraska.ImageViewer.dataCheckTimer** (optional) <br />
 Time (in seconds) between checks for updates in the CSV file. The default time is set to 180 seconds. <br />
 **edu.nebraska.ImageViewer.defaultBackground** (optional) <br />
-This value can be set to "DefaultBackgroundNoLogo" in order to remove the MDM Image Viewer logo from the default background image. <br />
+This value can be set to "DefaultBackgroundNoLogo" in order to remove the MDM Image Viewer logo from the default background image. <br />**edu.nebraska.ImageViewer.defaultDescription** (optional) <br />Replace the AirPlay description with a custom one. <br />**edu.nebraska.ImageViewer.defaultSubtitle** (optional) <br />Replace the AirPlay subtitle "CHOOSE THIS APPLE TV" with a custom one. <br />
 
 
 *Sample configuration preferences:*
@@ -86,7 +86,7 @@ Help us fix the problem as quickly as possible by following [Mozilla's guideline
 ## Patches and pull requests
 
 Your patches are welcome. Here's our suggested workflow:
- 
+
 * Fork the project.
 * Make your feature addition or bug fix.
 * Send us a pull request with a description of your work. Bonus points for topic branches!

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This value can be set to "DefaultBackgroundNoLogo" in order to remove the MDM Im
 	<integer>25</integer>
 	<key>edu.nebraska.ImageViewer.dataCheckTimer</key>
 	<integer>600</integer>
-  <key>edu.nebraska.ImageViewer.defaultSubtitle</key>
+        <key>edu.nebraska.ImageViewer.defaultSubtitle</key>
 	<string>SELECT THIS APPLE TV</string>
 	<key>edu.nebraska.ImageViewer.defaultDescription</key>
 	<string>New AirPlay description</string>


### PR DESCRIPTION
Hi,

I'm working for the university Erlangen-Nürnberg. We tested your app today and it is really helpful to deploy AirPlay screens in a branded design. But like the issue #1, it would be create for us to customize the AirPlay text. 

With this changes it should be possible to set the description text _("Wirelessly send what's....")_ and the AirPlay subtitle _("CHOSSE THIS APPLE TV")_ with an MDM. The default english text it the default one if there is no overwrite. 

Example AirPlay screen:
![Bildschirmfoto 2019-09-04 um 22 13 09](https://user-images.githubusercontent.com/17825363/64287922-30433900-cf61-11e9-9b62-13196e0637c4.png)
 